### PR TITLE
Added a Service so right-clicking text allows lookup in Ingredients

### DIFF
--- a/IGKApplicationDelegate.h
+++ b/IGKApplicationDelegate.h
@@ -57,6 +57,8 @@
 
 - (NSString *)developerDirectory;
 
+- (void)queryString:(NSString *)query;
+
 // Core Data Nonsense
 
 @property (nonatomic, retain, readonly) NSPersistentStoreCoordinator *persistentStoreCoordinator;

--- a/IGKApplicationDelegate.m
+++ b/IGKApplicationDelegate.m
@@ -111,6 +111,22 @@ const NSInteger IGKStoreVersion = 3;
 	applicationIsIndexing = NO;
 }
 
+- (void)queryString:(NSString *)query
+{
+	//Get the frontmost window
+	NSWindowController *windowController = nil;
+	if ([[[NSApp mainWindow] windowController] isKindOfClass:[IGKWindowController class]])
+		windowController = [[NSApp mainWindow] windowController];
+	
+	if (!windowController)
+		windowController = [windowControllers lastObject];
+	
+	if (!windowController)
+		windowController = [self newWindowIsIndexing:NO];
+	
+	[windowController executeUISideSearch:query];
+}
+
 - (void)getURL:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	//return;
@@ -129,18 +145,7 @@ const NSInteger IGKStoreVersion = 3;
 	
 	if ([action isCaseInsensitiveEqual:@"search"])
 	{
-		//Get the frontmost window
-		NSWindowController *windowController = nil;
-		if ([[[NSApp mainWindow] windowController] isKindOfClass:[IGKWindowController class]])
-			windowController = [[NSApp mainWindow] windowController];
-		
-		if (!windowController)
-			windowController = [windowControllers lastObject];
-		
-		if (!windowController)
-			windowController = [self newWindowIsIndexing:NO];
-		
-		[windowController executeUISideSearch:query];
+		[self queryString: query];
 	}
 }
 

--- a/Ingredients-Info.plist
+++ b/Ingredients-Info.plist
@@ -43,6 +43,29 @@
 	<string>Ingredients.sdef</string>
 	<key>NSAppleScriptEnabled</key>
 	<true/>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Lookup in Ingredients</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>lookupService</string>
+			<key>NSPortName</key>
+			<string>Ingredients</string>
+			<key>NSRequiredContext</key>
+			<dict>
+				<key>NSServiceCategory</key>
+				<string>public.item</string>
+			</dict>
+			<key>NSSendTypes</key>
+			<array>
+				<string>NSStringPboardType</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Ingredients-Info.plist
+++ b/Ingredients-Info.plist
@@ -49,7 +49,7 @@
 			<key>NSMenuItem</key>
 			<dict>
 				<key>default</key>
-				<string>Lookup in Ingredients</string>
+				<string>Look up in Ingredients</string>
 			</dict>
 			<key>NSMessage</key>
 			<string>lookupService</string>
@@ -58,7 +58,7 @@
 			<key>NSRequiredContext</key>
 			<dict>
 				<key>NSServiceCategory</key>
-				<string>public.item</string>
+				<string>public.text</string>
 			</dict>
 			<key>NSSendTypes</key>
 			<array>

--- a/Ingredients_AppDelegate.m
+++ b/Ingredients_AppDelegate.m
@@ -24,11 +24,22 @@
 {
 	NSRunAlertPanel(@"GET URL", @"", @"", @"", @"");
 }
+
+- (void)lookupService:(NSPasteboard *)pboard userData:(NSString *)data error:(NSString **)error
+{
+	NSArray *types = [pboard types];
+	if ([types containsObject:NSStringPboardType]){
+		NSString* query = [pboard stringForType:NSStringPboardType];
+		[kitController queryString: query];
+	}
+}
+
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {	
 	srandom((unsigned long)[NSDate timeIntervalSinceReferenceDate]);
 	PFMoveToApplicationsFolderIfNecessary();
 	
+	[NSApp setServicesProvider:self];
 	[kitController showWindow:nil];
 }
 


### PR DESCRIPTION
Based on learning about Ingredients last night on Twitter — https://twitter.com/chockenberry/status/36269596843450368 — (cool app, BTW), I thought it would be nice if I could use it from Xcode by right-click (or an assignable keyboard shortcut via the Keyboard system preference panel) without that script, so I added support for that via a Service (which was pretty easy to add given how your app was written).
