### PR TITLE
Fix crash when opening a header file. 

### DIFF
--- a/IGKTabController.mm
+++ b/IGKTabController.mm
@@ -17,6 +17,8 @@
 #import "CHSymbolButtonImage.h"
 #import "IGKSometimesCenteredTextCell.h"
 #import "IGKFrecencyStore.h"
+#import "NSArray+IGKAdditions.h"
+#import "NSString+Utilities.h"
 
 @interface IGKTabController ()
 

--- a/NSArray+IGKAdditions.h
+++ b/NSArray+IGKAdditions.h
@@ -14,7 +14,7 @@
 - (NSArray *)igk_map:(id (^)(id obj))rule;
 - (NSArray *)igk_filter:(BOOL (^)(id obj))predicate;
 
-- (NSArray *)igk_firstObject;
-- (NSArray *)igk_objectAtSoftIndex:(NSInteger)index;
+- (id)igk_firstObject;
+- (id)igk_objectAtSoftIndex:(NSInteger)index;
 
 @end

--- a/NSArray+IGKAdditions.m
+++ b/NSArray+IGKAdditions.m
@@ -49,11 +49,11 @@ NSComparisonResult IGKInverseComparisonResult(NSComparisonResult result)
 	return mappedArray;
 }
 
-- (NSArray *)igk_firstObject
+- (id)igk_firstObject
 {
 	return [self igk_objectAtSoftIndex:0];
 }
-- (NSArray *)igk_objectAtSoftIndex:(NSInteger)index
+- (id)igk_objectAtSoftIndex:(NSInteger)index
 {	
 	if (index < 0)
 		return [self igk_objectAtSoftIndex:[self count] + index];


### PR DESCRIPTION
Hey guys, I love Ingredients and noticed it was crashing when I tried to open a header file (clicking here for instance: http://cl.ly/83DU).  This simple patch fixes the crash, although the header file still cannot be found due to the app searching in the wrong place for these, at least with iOS docs (not finding the file was actually not causing the crash).

The crash was occurring with the block argument to -[NSArray igk_filter:] on line 709 of IGKTabController.mm.  There was nothing incorrect about the block; the compiler seemed to have been generating the actual block instructions incorrectly due to some missing #imports and incorrect return types.  Correcting those fixes the crash at least, but some more behavior needs to be added to search the correct header location on disk.

Hope this helps!
