### PR TITLE
Temporary fix for issue #31 (OS X Lion crashes)

### DIFF
--- a/IGKApplicationDelegate.mm
+++ b/IGKApplicationDelegate.mm
@@ -463,7 +463,7 @@ const NSInteger IGKStoreVersion = 4;
 - (dispatch_queue_t)backgroundQueue
 {
 	if (backgroundQueue == NULL)
-		backgroundQueue = dispatch_queue_create(NULL, NULL);
+		backgroundQueue = dispatch_get_main_queue();
 	
 	return backgroundQueue;
 }


### PR DESCRIPTION
Temporary fix for issue #31 (OS X Lion crashes); run the searcher on the main thread (apparently, Core Data is no longer happy with its separate thread on 10.7)
