### PR TITLE
Fix a resurrection error in FMDatabase

### DIFF
--- a/FMDatabase.m
+++ b/FMDatabase.m
@@ -103,11 +103,9 @@
 
 - (void)clearCachedStatements {
     
-    NSEnumerator *e = [cachedStatements objectEnumerator];
-    FMStatement *cachedStmt;
-
-    while ((cachedStmt = [e nextObject])) {
-    	[cachedStmt close];
+    for (NSString *key in cachedStatements) {
+      FMStatement *cachedStmt = [cachedStatements objectForKey:key];
+      [cachedStmt close];
     }
     
     [cachedStatements removeAllObjects];


### PR DESCRIPTION
The solution uses fast enumeration of dictionaries, which has been introduced to Objective-C in version 2.0.
